### PR TITLE
Modifier should be set separately on base and extended blocks

### DIFF
--- a/.bemrc.js
+++ b/.bemrc.js
@@ -9,6 +9,9 @@ module.exports = {
         './tests/fixtures3.blocks' : {
             scheme : 'flat',
             naming : 'origin'
+        },
+        './tests/fixtures4.blocks' : {
+            scheme : 'nested'
         }
     },
     modules : {

--- a/tests/bemClassName.spec.js
+++ b/tests/bemClassName.spec.js
@@ -11,6 +11,7 @@ import MyBlockElemWithContent from 'b:MyBlock e:ElemWithContent';
 import InheritedBlock from 'b:InheritedBlock';
 import InheritedElem from 'b:InheritedBlock e:IElem';
 import InheritedElemFromBlock from 'b:InheritedBlock e:ElemFromBlock';
+import ExtendedBlock from 'b:ExtendedBlock m:baseMod';
 import AnotherNamingBlockElem from 'b:another-naming-block e:elem';
 
 describe('Entity without declaration', () => {
@@ -288,6 +289,10 @@ describe('Entity with declaration', () => {
     it('Should inherit naming', () => {
         expect(getClassName(<AnotherNamingBlockElem/>))
             .toBe('another-naming-block__elem another-naming-block__elem--try');
+    });
+
+    it('Shold properly inherit mods', () => {
+        expect(getClassName(<ExtendedBlock baseMod/>)).toBe('ExtendedBlock ExtendedBlock_baseMod MixedBlock');
     });
 });
 

--- a/tests/fixtures4.blocks/BaseBlock/BaseBlock.js
+++ b/tests/fixtures4.blocks/BaseBlock/BaseBlock.js
@@ -1,0 +1,6 @@
+import { decl } from 'bem-react-core';
+
+export default decl({
+    block : 'BaseBlock'
+}, {
+});

--- a/tests/fixtures4.blocks/BaseBlock/_baseMod/BaseBlock_baseMod.js
+++ b/tests/fixtures4.blocks/BaseBlock/_baseMod/BaseBlock_baseMod.js
@@ -1,0 +1,6 @@
+import { declMod } from 'bem-react-core';
+
+export default declMod({ baseMod : true }, {
+    block : 'BaseBlock'
+}, {
+});

--- a/tests/fixtures4.blocks/ExtendedBlock/ExtendedBlock.js
+++ b/tests/fixtures4.blocks/ExtendedBlock/ExtendedBlock.js
@@ -1,0 +1,7 @@
+import { decl } from 'bem-react-core';
+import BaseBlock from 'b:BaseBlock';
+
+export default decl(BaseBlock, {
+    block : 'ExtendedBlock'
+}, {
+});

--- a/tests/fixtures4.blocks/ExtendedBlock/_baseMod/ExtendedBlock_baseMod.js
+++ b/tests/fixtures4.blocks/ExtendedBlock/_baseMod/ExtendedBlock_baseMod.js
@@ -1,6 +1,10 @@
 import { declMod } from 'bem-react-core';
+import 'b:BaseBlock m:baseMod';
 
 export default declMod({ baseMod : true }, {
-    block : 'BaseBlock'
+    block : 'ExtendedBlock',
+    addMix() {
+        return { block : 'MixedBlock' };
+    }
 }, {
 });

--- a/tests/fixtures4.blocks/ExtendedBlock/_baseMod/ExtendedBlock_baseMod.js
+++ b/tests/fixtures4.blocks/ExtendedBlock/_baseMod/ExtendedBlock_baseMod.js
@@ -1,0 +1,6 @@
+import { declMod } from 'bem-react-core';
+
+export default declMod({ baseMod : true }, {
+    block : 'BaseBlock'
+}, {
+});


### PR DESCRIPTION
Original task: https://nda.ya.ru/3TTfpA

Example:
```js
const A = decl({ block : 'a' });;
const Amod = declMod({ mod : true }, { block : 'a' });

const AComponent = applyDecls(A, Amod);

const B = decl(AComponent, { block : 'b' });
const Bmod = declMod({ mod : true }, { block : 'b' });

const BComponent = applyDecls(B, Bmod);

const jsx = <BComponent mod>;
// <div class="a b b_mod"></div>
```

Also would be nice to have a way to pass mod to any of base blocks (`AComponent` in example).