### PR TITLE
Allowing single mixes

### DIFF
--- a/src/Bem.js
+++ b/src/Bem.js
@@ -67,7 +67,7 @@ export default function({ preset, naming }) {
                     });
 
                     if(mix) {
-                        const mixedEntities = [].concat(...mix).reduce((uniq, mixed) => {
+                        const mixedEntities = [].concat(mix).reduce((uniq, mixed) => {
                             if(!mixed) return uniq;
 
                             const k = `${mixed.block}$${mixed.elem}`;

--- a/src/Component.js
+++ b/src/Component.js
@@ -32,7 +32,7 @@ export default function(Bem) {
                     block : this.block,
                     elem : this.elem,
                     mods : this.mods(props),
-                    mix : [this.mix(props), this.addMix(props)],
+                    mix : [].concat(this.mix(props), this.addMix(props)),
                     cls : this.cls(props),
                     children : this.content(props, props.children)
                 });

--- a/tests/bemClassName.spec.js
+++ b/tests/bemClassName.spec.js
@@ -57,6 +57,9 @@ describe('Entity without declaration', () => {
     });
 
     it('Block should allow adding mix', () => {
+        expect(getClassNames(<Bem block="Block" mix={{ block : 'Block2' }}/>))
+            .toContain('Block2');
+
         expect(getClassNames(<Bem block="Block" mix={[{ block : 'Block2' }]}/>))
             .toContain('Block2');
 
@@ -65,6 +68,10 @@ describe('Entity without declaration', () => {
     });
 
     it('Elem should allow adding mix', () => {
+        expect(getClassNames(
+            <Bem block="Block" elem="Elem" mix={{ block : 'Block2', elem : 'Elem2' }}/>
+        )).toContain('Block2-Elem2');
+
         expect(getClassNames(
             <Bem block="Block" elem="Elem" mix={[{ block : 'Block2', elem : 'Elem2' }]}/>
         )).toContain('Block2-Elem2');
@@ -238,6 +245,9 @@ describe('Entity with declaration', () => {
     });
 
     it('Block should allow adding mix', () => {
+        expect(getClassNames(<MyBlock mix={{ block : 'Block2' }}/>))
+            .toContain('Block2');
+
         expect(getClassNames(<MyBlock mix={[{ block : 'Block2' }]}/>))
             .toContain('Block2');
 
@@ -246,6 +256,10 @@ describe('Entity with declaration', () => {
     });
 
     it('Elem should allow adding mix', () => {
+        expect(getClassNames(
+            <MyBlockElem mix={{ block : 'Block2', elem : 'Elem2' }}/>
+        )).toContain('Block2-Elem2');
+
         expect(getClassNames(
             <MyBlockElem mix={[{ block : 'Block2', elem : 'Elem2' }]}/>
         )).toContain('Block2-Elem2');


### PR DESCRIPTION
~Fixing~ Reducing braces in mix notation `mix={[{ block: 'abc' }]}`.

Now everybody can write `mix={{ block: 'abc' }}`.