### PR TITLE
TypeScript: <Bem mix=...> accepts only object, but not also array

### DIFF
--- a/src/presets/React.d.ts
+++ b/src/presets/React.d.ts
@@ -22,7 +22,7 @@ declare module 'bem-react-core' {
         elemMods?: Mods;
     }
 
-    type Mix = JsonMix | string | JSX.Element;
+    type Mix = JsonMix | JsonMix[] | string | JSX.Element | JSX.Element[];
     type Replaceble = null | number | string | JSX.Element;
 
     interface Block {


### PR DESCRIPTION
fixes https://github.com/bem/bem-react-core/issues/226